### PR TITLE
Update tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,6 @@
       "@my/ui/*": ["./packages/ui/*"]
     }
   },
-  "extends": "expo/tsconfig.base",
+  "extends": "tsconfig.base",
   "exclude": ["**/node_modules", "**/dist", "**/types", "apps/next/out", "apps/next/.next", "apps/next/.tamagui"]
 }


### PR DESCRIPTION
Ran into some IDE errors complaining about `tsconfig` not being able to find `expo/tsconfig.base`. Either `tsconfig.base` located in the root directory is supposed to be in the `expo` directory, or `"extends"` just needs to be corrected. This PR corrects `"extends"` but feel free to address however makes sense?