### PR TITLE
Some fixes for Nextjs with App dir

### DIFF
--- a/apps/next/app-demo/TamaguiProvider.tsx
+++ b/apps/next/app-demo/TamaguiProvider.tsx
@@ -47,6 +47,7 @@ export const TamaguiProvider = ({ children }: { children: React.ReactNode }) => 
 
   return (
     <NextThemeProvider
+      skipNextHead
       onChangeTheme={(next) => {
         setTheme(next as any)
       }}

--- a/apps/next/package.json
+++ b/apps/next/package.json
@@ -20,6 +20,7 @@
     "react-native": "0.72.5",
     "react-native-web": "~0.19.6",
     "react-native-web-lite": "latest",
+    "tamagui": "latest",
     "vercel": "latest"
   },
   "devDependencies": {


### PR DESCRIPTION
For my change in TamaguiProvider, I saw that in the docs setting up Tamagui + Nextjs app dir, y'all said:

> Additionally, you will need to add the skipNextHead prop to your <NextThemeProvider>, as the internal usage of next/head is not supported in the app directory.

---

As for my change in package.json, [this line](https://github.com/tamagui/starter-free/blob/main/apps/next/app-demo/TamaguiProvider.tsx#L11) imports `tamagui`. In my app, I had to add it to the nextjs package.json, without it, nothing worked and vscode gave me a warning that `tamagui` cannot be found (after I deleted `node_modules` and reinstalled everything again). But when I tried this starter repo, it worked fine without adding it to package.json.

---

another thing, do we need both [this](https://github.com/psycho-baller/starter-free/blob/4c71909d5a6d0979d7f1fcd1df727336f7281988/apps/next/app-demo/TamaguiProvider.tsx#L22C1-L24C2), and [this](https://github.com/psycho-baller/starter-free/blob/4c71909d5a6d0979d7f1fcd1df727336f7281988/apps/next/tamagui.config.ts#L8C1-L10C2)?