### PR TITLE
Update packages/app tsconfig.json

### DIFF
--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -3,7 +3,11 @@
   "include": ["**/*.ts", "**/*.tsx"],
   "compilerOptions": {
     "composite": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "paths": {
+      "app/*": ["./packages/app/*"],
+      "@my/ui/*": ["./packages/ui/*"]
+    }
   },
   "references": []
 }


### PR DESCRIPTION
Even if paths are specified in tsconfig.base, without specifying this import also here, when you want to import things from "packages/app" folder vscode will provide imports suggesionts from "packages/app/<whatever>" which is wrong: the correct import path for code located in packages/app folder is "app/<whatever>"