### PR TITLE
3009 Broken pages navigation in Free - Expo + Next in a production re…

### DIFF
--- a/apps/next/pages/pages-example-user/[id].tsx
+++ b/apps/next/pages/pages-example-user/[id].tsx
@@ -5,7 +5,7 @@ import { createParam } from 'solito'
 const { useParam } = createParam<{ id: string }>()
 
 export default function Page() {
-  const id = useParam('id') as unknown as string
+  const [id] = useParam('id') as unknown as string
   return (
     <>
       <Head>


### PR DESCRIPTION
Pages navigation is broken as described in this issue https://github.com/tamagui/tamagui/issues/3009.

### Steps to reproduce
- npm create `tamagui@latest`
- choose `Free - Expo + Next in a production ready monorepo`
- `yarn install`
- `yarn web`
- switch to page router
- click 'Link to user'

Expected output:
`User ID: nate`

Actuall output:
```
User ID: nate,(value, options)=>{ hasSetState.current = true; const { pathname, query } = (_router__WEBPACK_IMPORTED_MODULE_4___default()); const newQuery = { ...query }; if (value != null && value !== "") { if (stableStringify.current) { newQuery[name] = stableStringify.current(value); } else { newQuery[name] = value; } } else { delete newQuery[name]; } if (stableParamsToClear.current) { for (const paramKey of stableParamsToClear.current){ delete newQuery[paramKey]; } } const willChangeExistingParam = query[name] && newQuery[name]; let action = willChangeExistingParam ? (_router__WEBPACK_IMPORTED_MODULE_4___default().replace) : (_router__WEBPACK_IMPORTED_MODULE_4___default().push); if (options === null || options === void 0 ? void 0 : options.webBehavior) { action = (_router__WEBPACK_IMPORTED_MODULE_4___default())[options.webBehavior]; } action({ pathname, query: newQuery }, undefined, { shallow: true }); }
```

Problem is `userParam` reurns `id` and `fn`. Simple  `const [id] = useParam('id')` does the trick and navigation behaves as expected.