### PR TITLE
Update README.md with instruction to fix web:prod in pages mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ You can add other folders inside of `packages/` if you know what you're doing an
 > - rename `pages-example-user` to `user` and be sure to update `linkTarget` in `screen.tsx` to `user` as well
 > - delete `SwitchRouterButton.tsx` component and remove it from `screen.tsx` and `packages/ui/src/index.tsx`
 > - search for `pagesMode` keyword and remove it
+> - set Tamagui `appDir` variable to `false` in `apps/next/next.config.js` 
 
 ## 🏁 Start the app
 


### PR DESCRIPTION
Commit 4bfb354 Set `appDir` to `true` by default, which causes the web:prod build to fail in pages mode. Updated the README to include instructions for resolving this issue.

`Global CSS cannot be imported from files other than your Custom <App>. Due to the Global nature of stylesheets, and to avoid conflicts, Please move all first-party global CSS imports to pages/_app.js. Or convert the import to Component-Level CSS (CSS Modules).`